### PR TITLE
feat(loki): add default retention

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -10,7 +10,7 @@ Welcome to the latest release of the `logging` module of [`SIGHUP Distribution`]
 
 ## Bug Fixes and Changes 🐛
 
-- [[#186](https://github.com/sighupio/module-logging/pull/186)]: This PR adds the retention period to Loki stack. The retention period for logs stored in Loki is 30 days.
+- [[#186](https://github.com/sighupio/module-logging/pull/186)]: This PR adds the retention period to Loki stack. The default retention period for logs stored in Loki is 30 days, can be customized with a patch.
 
 
 ## Breaking Changes 💔

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -10,7 +10,7 @@ Welcome to the latest release of the `logging` module of [`SIGHUP Distribution`]
 
 ## Bug Fixes and Changes 🐛
 
-- [[#TBD](https://github.com/sighupio/module-logging/pull/TBD)]: This PR adds the retention to Loki stack. The retention period for logs stored in Loki is 30 days. Users can edit this with a common patch.
+- [[#186](https://github.com/sighupio/module-logging/pull/186)]: This PR adds the retention period to Loki stack. The retention period for logs stored in Loki is 30 days.
 
 
 ## Breaking Changes 💔

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,0 +1,36 @@
+# Logging Core Module Release TBD
+
+Welcome to the latest release of the `logging` module of [`SIGHUP Distribution`](https://github.com/sighupio/distribution) maintained by team SIGHUP by ReeVo.
+
+
+## Component Images 🚢
+
+| Component               | Supported Version                                                                                  | Previous Version               |
+| ----------------------- | -------------------------------------------------------------------------------------------------- | ------------------------------ |
+
+## Bug Fixes and Changes 🐛
+
+- [[#TBD](https://github.com/sighupio/module-logging/pull/TBD)]: This PR adds the retention to Loki stack. The retention period for logs stored in Loki is 30 days. Users can edit this with a common patch.
+
+
+## Breaking Changes 💔
+
+
+
+## Update Guide 🦮
+
+
+
+### Upgrade using the distribution
+
+To upgrade the module using the distribution please refer to the [`official documentation`](https://docs.kubernetesfury.com/docs/upgrades/upgrades)
+
+### Manual Upgrade
+
+ℹ️ **Note:** Manually upgrading the module is deprecated. It is recommended to use it with the [`SIGHUP Distribution`](https://github.com/sighupio/distribution).
+
+To upgrade the module run:
+
+```bash
+kustomize build | kubectl apply -f - --server-side
+```

--- a/katalog/loki-distributed/configs/config.yaml
+++ b/katalog/loki-distributed/configs/config.yaml
@@ -58,6 +58,7 @@ limits_config:
   split_queries_by_interval: 15m
   volume_enabled: true
   max_label_names_per_series: 30
+  retention_period: 720h
 memberlist:
   join_members:
   - loki-distributed-memberlist
@@ -117,6 +118,12 @@ storage_config:
     resync_interval: 5s
     index_gateway_client:
       server_address: dns+loki-distributed-index-gateway-headless.logging.svc.cluster.local:9095
+compactor:
+  working_directory: /var/loki/compactor
+  retention_enabled: true
+  retention_delete_delay: 2h
+  retention_delete_worker_count: 150
+  delete_request_store: s3
 tracing:
   enabled: false
 


### PR DESCRIPTION
### Summary 💡

This pull request sets a default retention period of 30 days for the Loki stack.

Relates: [sighupio/module-logging/issues/177](https://github.com/sighupio/module-logging/issues/177)

### Description 📝

The change includes:

- Support for global retention via the `retention_period` setting under `limits_config`
- Usage of the existing `persistentvolumeclaim/data-loki-distributed-compactor` as the working directory for the compactor

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] Checked that logs older than configured period are deleted by the compactor with SD version 1.31.1

### Future work 🔧

None
