### PR TITLE
fix(minio-ha): tag mc image

### DIFF
--- a/katalog/minio-ha/kustomization.yaml
+++ b/katalog/minio-ha/kustomization.yaml
@@ -16,6 +16,8 @@ resources:
 images:
   - name: registry.sighup.io/fury/groundnuty/k8s-wait-for
     newTag: v1.6
+  - name: registry.sighup.io/fury/minio/mc
+    newTag: RELEASE.2025-02-21T16-00-46Z
 
 secretGenerator:
   - name: minio-logging


### PR DESCRIPTION
### Summary 💡

Tag minio's mc tool container image to version RELEASE.2025-02-21T16-00-46Z

Fixes https://github.com/sighupio/module-logging/issues/188


### Description 📝

See summary.

> [!NOTE]
> I've retagged `latest` as `RELEASE.2025-02-21T16-00-46Z` in our registry in the meantime.

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] Tested the change with SD version 1.31.1

### Future work 🔧

None