### PR TITLE
feat: increase default resources and thread count

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ High level diagram of the stack:
 
 ## Packages
 
-The following packages are included in the Logging Module module:
+The following packages are included in the Logging module:
 
 | Package                                                | Version                        | Description                                                                          |
 | ------------------------------------------------------ | ------------------------------ | ------------------------------------------------------------------------------------ |
@@ -66,11 +66,17 @@ Check the [compatibility matrix][compatibility-matrix] for additional informatio
 
 ## Usage
 
+> [!NOTE]
+> Instructions below are for deploying the module using a legacy version of furyctl, that required manual intervention and managing each module individually.
+>
+> Latest versions of furyctl automate the whole cluster lifecycle and it is recommended to use the latest version of furyctl instead.
+
+
 ### Prerequisites
 
 | Tool                        | Version    | Description                                                                                                                                                    |
 | --------------------------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [furyctl][furyctl-repo]     | `>=0.25.0` | The recommended tool to download and manage SD modules and their packages. To learn more about `furyctl` read the [official documentation][furyctl-repo].     |
+| [furyctl][furyctl-repo]     | `>=0.25.0` | The recommended tool to download and manage SD modules and their packages. To learn more about `furyctl` read the [official documentation][furyctl-repo].      |
 | [kustomize][kustomize-repo] | `>=3.10.0` | Packages are customized using `kustomize`. To learn how to create your customization layer with `kustomize`, please refer to the [repository][kustomize-repo]. |
 
 ### Deployment with OpenSearch

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -18,6 +18,7 @@ Welcome to the latest release of the `logging` module of [`SIGHUP Distribution`]
 - [[#189](https://github.com/sighupio/module-logging/pull/189)]: Fixed a bug with `minio-ha`, where the image for the `mc` utility was missing the tag and using latest in consequence. This could lead to issues when upstream releases breaking changes.
 - Logging Operated: Increased fluentd's default resource requests (1 CPU, 700 Mi Memory) and limits (2 CPU, 1.5 Gi Memory) and fluentbit's default requests (CPU: 100m, Memory: 100M) based on latest usage statistics on production clusters.
 - Configs: Increased the overall flush threads count on all the output plugins to improve flush performance over the network.
+- Loki Configs: Increased the overall flush threads count on all the output plugins to improve flush performance over the network.
 
 ## Breaking Changes 💔
 

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -16,6 +16,8 @@ Welcome to the latest release of the `logging` module of [`SIGHUP Distribution`]
 ## Bug Fixes and Changes 🐛
 
 - [[#189](https://github.com/sighupio/module-logging/pull/189)]: Fixed a bug with `minio-ha`, where the image for the `mc` utility was missing the tag and using latest in consequence. This could lead to issues when upstream releases breaking changes.
+- Logging Operated: Increased fluentd's default resource requests (1 CPU, 700 Mi Memory) and limits (2 CPU, 1.5 Gi Memory) and fluentbit's default requests (CPU: 100m, Memory: 100M) based on latest usage statistics on production clusters.
+- Configs: Increased the overall flush threads count on all the output plugins to improve flush performance over the network.
 
 ## Breaking Changes 💔
 

--- a/katalog/configs/README.md
+++ b/katalog/configs/README.md
@@ -1,22 +1,23 @@
 # Logging operator configs for OpenSearch
 
-This package is a collection of logging operator Flow/ClusterFlow and Output/ClusterOutput configs to be used together with OpenSearch.
+This package is a collection of logging operator Flow/ClusterFlow and Output/ClusterOutput configs to be used together with **OpenSearch**.
+
+> [WARNING!]
+> This package cannot be used together with `loki-configs` package, one excludes the other.
 
 ## Requirements
 
-- Kustomize >= `3.5.3`
+- Kustomize >= `5.6.0`
 - [logging-operated](../logging-operated)
 - [logging-operator](../logging-operator)
 
 ## Configuration
 
-> ⚠️ This package cannot be used together with `loki-configs` package, one excludes the other.
-
 Configurations available:
 
 - [configs](configs): all the configurations.
 - [configs/kubernetes](configs/kubernetes): only the cluster wide pods logging configuration (infrastructural namespaced excluded).
-- [configs/infra](configs/infra): only the infrastructural namespaces logs  
+- [configs/infra](configs/infra): only the infrastructural namespaces logs
 - [configs/ingress-nginx](configs/ingress-nginx): only the nginx-ingress-controller logging configuration.
 - [configs/audit](configs/audit): all the Kubernetes audit logs related configurations (with master selector and tolerations).
 - [configs/events](configs/events): all the Kubernetes events related configurations (with master selector and tolerations).
@@ -26,7 +27,7 @@ Configurations available:
 
 ## Deployment
 
-You can deploy all the configurations by running the following command in the root of the project:
+You can deploy all the configurations by running the following command in the `configs` folder:
 
 ```shell
 kustomize build | kubectl apply -f -

--- a/katalog/configs/README.md
+++ b/katalog/configs/README.md
@@ -2,7 +2,7 @@
 
 This package is a collection of logging operator Flow/ClusterFlow and Output/ClusterOutput configs to be used together with **OpenSearch**.
 
-> [WARNING!]
+> [!WARNING]
 > This package cannot be used together with `loki-configs` package, one excludes the other.
 
 ## Requirements

--- a/katalog/configs/audit/output.yml
+++ b/katalog/configs/audit/output.yml
@@ -33,3 +33,4 @@ spec:
       retry_max_interval: "30"
       retry_forever: true
       overflow_action: "block"
+      flush_thread_count: 4

--- a/katalog/configs/events/output.yml
+++ b/katalog/configs/events/output.yml
@@ -33,3 +33,4 @@ spec:
       retry_max_interval: "30"
       retry_forever: true
       overflow_action: "block"
+      flush_thread_count: 4

--- a/katalog/configs/infra/cluster-output.yml
+++ b/katalog/configs/infra/cluster-output.yml
@@ -33,4 +33,4 @@ spec:
       retry_max_interval: "30"
       retry_forever: true
       overflow_action: "block"
-      flush_thread_count: 4
+      flush_thread_count: 8

--- a/katalog/configs/ingress-nginx/output.yml
+++ b/katalog/configs/ingress-nginx/output.yml
@@ -33,3 +33,4 @@ spec:
       retry_max_interval: "30"
       retry_forever: true
       overflow_action: "block"
+      flush_thread_count: 4

--- a/katalog/configs/kubernetes/cluster-output.yml
+++ b/katalog/configs/kubernetes/cluster-output.yml
@@ -33,4 +33,4 @@ spec:
       retry_max_interval: "30"
       retry_forever: true
       overflow_action: "block"
-      flush_thread_count: 4
+      flush_thread_count: 8

--- a/katalog/configs/systemd/common/output.yml
+++ b/katalog/configs/systemd/common/output.yml
@@ -32,3 +32,4 @@ spec:
       retry_max_interval: "30"
       retry_forever: true
       overflow_action: "block"
+      flush_thread_count: 4

--- a/katalog/configs/systemd/etcd/output.yml
+++ b/katalog/configs/systemd/etcd/output.yml
@@ -26,3 +26,4 @@ spec:
       retry_max_interval: "30"
       retry_forever: true
       overflow_action: "block"
+      flush_thread_count: 4

--- a/katalog/logging-operated/README.md
+++ b/katalog/logging-operated/README.md
@@ -8,7 +8,7 @@ It also deploys a MinIO instance for storing all the logs rejected from the conf
 ## Requirements
 
 - Kubernetes >= `1.24.0`
-- Kustomize >= `v3.5.3`
+- Kustomize >= `v5.6.0`
 - [logging-operator][logging-operator]
 - [prometheus-operator][prometheus-operator]
 - [minio-ha](../minio-ha)

--- a/katalog/logging-operated/fluentd-fluentbit.yml
+++ b/katalog/logging-operated/fluentd-fluentbit.yml
@@ -42,11 +42,11 @@ spec:
       prometheusRules: true
     resources:
       limits:
-        cpu: 1000m
-        memory: 600Mi
+        cpu: 2000m
+        memory: 1500Mi
       requests:
-        cpu: 300m
-        memory: 400Mi
+        cpu: 1000m
+        memory: 700Mi
   controlNamespace: logging
 ---
 apiVersion: logging.banzaicloud.io/v1beta1
@@ -80,7 +80,7 @@ spec:
       memory: 300M
     requests:
       cpu: 100m
-      memory: 50M
+      memory: 100M
   positiondb:
     hostPath:
       path: /var/log/infra-fluentbit-pos

--- a/katalog/loki-configs/README.md
+++ b/katalog/loki-configs/README.md
@@ -1,28 +1,29 @@
 # Logging operator configs for Loki
 
-This package is a collection of logging operator Flow/ClusterFlow and Output/ClusterOutput configs to be used together with Loki.
+This package is a collection of logging operator Flow/ClusterFlow and Output/ClusterOutput configs to be used together with **Loki**.
 
 ## Requirements
 
-- Kustomize >= `3.5.3`
+- Kustomize >= `5.6.0`
 - [logging-operated](../logging-operated)
 - [logging-operator](../logging-operator)
 
 ## Configuration
 
-> ⚠️ This package cannot be used together with `configs` package, one excludes the other.
+> [WARNING!]
+> This package cannot be used together with `configs` package, one excludes the other.
 
 Configurations available (patched from the base [configs](../configs) ) :
 
-- [configs](configs): all the configurations.
-- [configs/kubernetes](configs/kubernetes): only the cluster wide pods logging configuration (infrastructural namespaced excluded).
-- [configs/infra](configs/infra): only the infrastructural namespaces logs  
-- [configs/ingress-nginx](configs/ingress-nginx): only the nginx-ingress-controller logging configuration.
-- [configs/audit](configs/audit): all the Kubernetes audit logs related configurations (with master selector and tolerations).
-- [configs/events](configs/events): all the Kubernetes events related configurations (with master selector and tolerations).
-- [configs/systemd](configs/systemd): all the systemd related configurations.
-- [configs/systemd/kubelet](configs/systemd/common): kubelet, docker, ssh systemd service logs configuration.
-- [configs/systemd/etcd](configs/systemd/etcd): only the etcd service logs configuration (with master selector and tolerations).
+- [loki-configs](loki-configs): all the configurations.
+- [loki-configs/kubernetes](loki-configs/kubernetes): only the cluster wide pods logging configuration (infrastructural namespaced excluded).
+- [loki-configs/infra](loki-configs/infra): only the infrastructural namespaces logs
+- [loki-configs/ingress-nginx](loki-configs/ingress-nginx): only the nginx-ingress-controller logging configuration.
+- [loki-configs/audit](loki-configs/audit): all the Kubernetes audit logs related configurations (with master selector and tolerations).
+- [loki-configs/events](loki-configs/events): all the Kubernetes events related configurations (with master selector and tolerations).
+- [loki-configs/systemd](loki-configs/systemd): all the systemd related configurations.
+- [loki-configs/systemd/kubelet](loki-configs/systemd/common): kubelet, docker, ssh systemd service logs configuration.
+- [loki-configs/systemd/etcd](loki-configs/systemd/etcd): only the etcd service logs configuration (with master selector and tolerations).
 
 ## Deployment
 

--- a/katalog/loki-configs/README.md
+++ b/katalog/loki-configs/README.md
@@ -10,7 +10,7 @@ This package is a collection of logging operator Flow/ClusterFlow and Output/Clu
 
 ## Configuration
 
-> [WARNING!]
+> [!WARNING]
 > This package cannot be used together with `configs` package, one excludes the other.
 
 Configurations available (patched from the base [configs](../configs) ) :

--- a/katalog/loki-configs/audit/output.yml
+++ b/katalog/loki-configs/audit/output.yml
@@ -22,3 +22,4 @@ spec:
       retry_max_interval: "30"
       retry_forever: true
       overflow_action: "block"
+      flush_thread_count: 4

--- a/katalog/loki-configs/events/output.yml
+++ b/katalog/loki-configs/events/output.yml
@@ -22,3 +22,4 @@ spec:
       retry_max_interval: "30"
       retry_forever: true
       overflow_action: "block"
+      flush_thread_count: 4

--- a/katalog/loki-configs/infra/cluster-output.yml
+++ b/katalog/loki-configs/infra/cluster-output.yml
@@ -22,4 +22,4 @@ spec:
       retry_max_interval: "30"
       retry_forever: true
       overflow_action: "block"
-
+      flush_thread_count: 8

--- a/katalog/loki-configs/ingress-nginx/output.yml
+++ b/katalog/loki-configs/ingress-nginx/output.yml
@@ -22,3 +22,4 @@ spec:
       retry_max_interval: "30"
       retry_forever: true
       overflow_action: "block"
+      flush_thread_count: 4

--- a/katalog/loki-configs/kubernetes/cluster-output.yml
+++ b/katalog/loki-configs/kubernetes/cluster-output.yml
@@ -22,3 +22,4 @@ spec:
       retry_max_interval: "30"
       retry_forever: true
       overflow_action: "block"
+      flush_thread_count: 8

--- a/katalog/loki-configs/systemd/common/output.yml
+++ b/katalog/loki-configs/systemd/common/output.yml
@@ -22,3 +22,4 @@ spec:
       retry_max_interval: "30"
       retry_forever: true
       overflow_action: "block"
+      flush_thread_count: 4

--- a/katalog/loki-configs/systemd/etcd/output.yml
+++ b/katalog/loki-configs/systemd/etcd/output.yml
@@ -22,3 +22,4 @@ spec:
       retry_max_interval: "30"
       retry_forever: true
       overflow_action: "block"
+      flush_thread_count: 4


### PR DESCRIPTION
### Summary 💡

This PR:
- Increases the default resources limits and requests for fluentd and fluentbit, based on behaviour that we've been seeing on production clusters.
- Adds where missing and increases when present the `flush_thread_count` parameter in the Configs and Loki Configs.


### Description 📝

Increases the default resources limits and requests for fluentd and fluentbit, based on behaviour that we've been seeing on production clusters.

Note that this value tempts to be a better default but tailored configuration may be still needed for each cluster.


Adds where missing and increases when present the value of `flush_thread_count` in both the (OpenSearch) Configs and Loki Configs, so fluentd flushing to remote storage is faster and not limited to a single thread.

This was particularly bad for Loki Configs, because we were using the OpenSeach configs as kustomize base and patching them to drop the OpenSeach part from the config and add the Loki related configuration. The `flush_thread_count` paramater is under the OpenSearch config though, so this parameter was completely removed in Loki Configs outputs and cluster outputs.

### Breaking Changes 💔

Not a breaking change per-se, but notice that the resources request have been increased for fluentd and fluenbit.

**This could cause scheduling issues on clusters that are already close to 100% node utilisation.**

### Tests performed 🧪

- [X] Tested the change with SD version v1.32.1-rc.1. Logging stack is working and the new values are present.

### Future work 🔧

I will be making a PR to the distribution to expose the tuning of resources requests and limits for fluentd,fluentbit, and for Loki.