### PR TITLE
feat: update opensearch (and opensearch-dashboard) to 3.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ The following packages are included in the Logging module:
 
 | Package                                                | Version                        | Description                                                                          |
 | ------------------------------------------------------ | ------------------------------ | ------------------------------------------------------------------------------------ |
-| [opensearch-single](katalog/opensearch-single)         | `v2.19.1`                      | Single node opensearch deployment. Not intended for production use.                  |
-| [opensearch-triple](katalog/opensearch-triple)         | `v2.19.1`                      | Three node high-availability opensearch deployment                                   |
-| [opensearch-dashboards](katalog/opensearch-dashboards) | `v2.19.1`                      | Analytics and visualization platform for Opensearch                                  |
+| [opensearch-single](katalog/opensearch-single)         | `v3.2.0`                       | Single node opensearch deployment. Not intended for production use.                  |
+| [opensearch-triple](katalog/opensearch-triple)         | `v3.2.0`                       | Three node high-availability opensearch deployment                                   |
+| [opensearch-dashboards](katalog/opensearch-dashboards) | `v3.2.0`                       | Analytics and visualization platform for Opensearch                                  |
 | [logging-operator](katalog/logging-operator)           | `v6.0.3`                       | Banzai logging operator, manages fluentbit/fluentd and their configurations          |
 | [logging-operated](katalog/logging-operated)           | `-`                            | fluentd and fluentbit deployment using logging operator                              |
 | [configs](katalog/configs)                             | `-`                            | Logging pipeline configs to gather various types of logs and send them to OpenSearch |

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -9,8 +9,8 @@ This release delivers enhanced logging capabilities with improved performance, K
 
 | Component               | Supported Version                                                                                  | Previous Version               |
 | ----------------------- | -------------------------------------------------------------------------------------------------- | ------------------------------ |
-| `opensearch`            | [`v2.19.1`](https://github.com/opensearch-project/OpenSearch/releases/tag/2.19.1)                  | `No Update`                    |
-| `opensearch-dashboards` | [`v2.19.1`](https://github.com/opensearch-project/OpenSearch-Dashboards/releases/tag/2.19.1)       | `No Update`                    |
+| `opensearch`            | [`v3.2.0`](https://github.com/opensearch-project/OpenSearch/releases/tag/3.2.0)                    | `v2.19.1`                      |
+| `opensearch-dashboards` | [`v3.2.0`](https://github.com/opensearch-project/OpenSearch-Dashboards/releases/tag/3.2.0)         | `v2.19.1`                      |
 | `logging-operator`      | [`v6.0.3`](https://github.com/kube-logging/logging-operator/releases/tag/6.0.3)                    | `v5.2.0`                       |
 | `loki-distributed`      | [`v3.4.2`](https://github.com/grafana/loki/releases/tag/v3.4.2)                                    | `No Update`                    |
 | `minio-ha`              | [`RELEASE.2025-02-28T09-55-16Z`](https://github.com/minio/minio/tree/RELEASE.2025-02-28T09-55-16Z) | `No Update`                    |
@@ -27,6 +27,11 @@ Updated logging-operator from v5.2.0 to v6.0.3 with enhanced Kubernetes 1.33 com
 - Increased fluentd's default resource requests (1 CPU, 700 Mi Memory) and limits (2 CPU, 1.5 Gi Memory) based on production usage statistics
 - Increased fluentbit's default requests (CPU: 100m, Memory: 100M) for better resource allocation
 - Enhanced flush performance with increased flush thread counts on all output plugins
+
+### OpenSearch Components
+
+Major version upgrade from v2.19.1 to v3.2.0 delivers significant improvements for log storage and search capabilities.
+
 
 ### Loki Components
 

--- a/katalog/opensearch-dashboards/MAINTENANCE.md
+++ b/katalog/opensearch-dashboards/MAINTENANCE.md
@@ -9,8 +9,8 @@ To maintain the Opensearch Dashboards package, you should follow these steps.
 3. Run the following commands:
 
   ```bash
-  VERSION=2.28.0 # update this to the latest chart version
-  IMAGE_TAG="2.19.1" # update this to the latest fury/opensearchproject/opensearch-dashboards image tag
+  VERSION=3.2.1 # update this to the latest chart version
+  IMAGE_TAG="3.2.0" # update this to the latest fury/opensearchproject/opensearch-dashboards image tag
   helm repo add opensearch https://opensearch-project.github.io/helm-charts/
   helm repo update
   helm pull opensearch/opensearch-dashboards --version $VERSION --untar --untardir /tmp # this command will download the chart in /tmp/opensearch-dashboards
@@ -19,7 +19,7 @@ To maintain the Opensearch Dashboards package, you should follow these steps.
   ```
 
   > [!TIP]
-  > Chart v2.28.0 uses OpenSearch Dashboards v2.19.1
+  > Chart v3.2.1 uses OpenSearch Dashboards v3.2.0
 
 What was customized:
 

--- a/katalog/opensearch-dashboards/MAINTENANCE.values.yaml
+++ b/katalog/opensearch-dashboards/MAINTENANCE.values.yaml
@@ -5,13 +5,13 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-opensearchHosts: "https://opensearch-cluster-master:9200"
+opensearchHosts: "http://opensearch-cluster-master:9200"
 replicaCount: 1
 
 image:
   repository: "registry.sighup.io/fury/opensearchproject/opensearch-dashboards"
   # override image tag, which is .Chart.AppVersion by default
-  tag: ""
+  tag: "3.2.0"
   pullPolicy: "IfNotPresent"
 
 startupProbe:

--- a/katalog/opensearch-dashboards/README.md
+++ b/katalog/opensearch-dashboards/README.md
@@ -14,7 +14,7 @@ stored in OpenSearch indices.
 
 ## Image repository and tag
 
-* OpenSearch Dashboards image: `opensearchproject/opensearch-dashboards:2.11.0`
+* OpenSearch Dashboards image: `opensearchproject/opensearch-dashboards:3.2.0`
 * OpenSearch Dashboards repo: [OpenSearch Dashboards on Github][opensearch-dashboards-github]
 * OpenSearch Dashboards documentation: [OpenSearch Dashboards at opensearch.org][opensearch-dashboards-doc]
 

--- a/katalog/opensearch-dashboards/deploy.yaml
+++ b/katalog/opensearch-dashboards/deploy.yaml
@@ -94,6 +94,8 @@ spec:
         image: "registry.sighup.io/fury/opensearchproject/opensearch-dashboards:3.2.0"
         imagePullPolicy: "IfNotPresent"
         command:
+          - /bin/bash
+          - -c
           - |
             /usr/share/opensearch-dashboards/bin/opensearch-dashboards-plugin remove securityDashboards
             ./opensearch-dashboards-docker-entrypoint.sh opensearch-dashboards

--- a/katalog/opensearch-dashboards/deploy.yaml
+++ b/katalog/opensearch-dashboards/deploy.yaml
@@ -11,7 +11,6 @@ metadata:
   labels:
     app.kubernetes.io/name: opensearch-dashboards
     app.kubernetes.io/instance: opensearch-dashboards
-
 ---
 # Source: opensearch-dashboards/templates/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -49,8 +48,8 @@ spec:
     protocol: TCP
     port: 9601
   selector:
-    app: opensearch-dashboards
-    release: "opensearch-dashboards"
+    app.kubernetes.io/name: opensearch-dashboards
+    app.kubernetes.io/instance: opensearch-dashboards
 ---
 # Source: opensearch-dashboards/templates/deployment.yaml
 apiVersion: apps/v1
@@ -66,13 +65,13 @@ spec:
     type: Recreate
   selector:
     matchLabels:
-      app: opensearch-dashboards
-      release: "opensearch-dashboards"
+      app.kubernetes.io/name: opensearch-dashboards
+      app.kubernetes.io/instance: opensearch-dashboards
   template:
     metadata:
       labels:
-        app: opensearch-dashboards
-        release: "opensearch-dashboards"
+        app.kubernetes.io/name: opensearch-dashboards
+        app.kubernetes.io/instance: opensearch-dashboards
     spec:
       securityContext:
         {}
@@ -92,8 +91,12 @@ spec:
             - ALL
           runAsNonRoot: true
           runAsUser: 1000
-        image: "registry.sighup.io/fury/opensearchproject/opensearch-dashboards:2.19.1"
+        image: "registry.sighup.io/fury/opensearchproject/opensearch-dashboards:3.2.0"
         imagePullPolicy: "IfNotPresent"
+        command:
+          - |
+            /usr/share/opensearch-dashboards/bin/opensearch-dashboards-plugin remove securityDashboards
+            ./opensearch-dashboards-docker-entrypoint.sh opensearch-dashboards
         readinessProbe:
           failureThreshold: 10
           initialDelaySeconds: 10
@@ -118,13 +121,6 @@ spec:
           tcpSocket:
             port: 5601
           timeoutSeconds: 5
-        command:
-          - sh
-          - -c
-          - |
-            /usr/share/opensearch-dashboards/bin/opensearch-dashboards-plugin remove securityDashboards
-            ./opensearch-dashboards-docker-entrypoint.sh opensearch-dashboards
-        args: []
         env:
         - name: OPENSEARCH_HOSTS
           value: "http://opensearch-cluster-master:9200"
@@ -159,13 +155,10 @@ metadata:
     app.kubernetes.io/name: opensearch-dashboards
     app.kubernetes.io/instance: opensearch-dashboards
 spec:
-  namespaceSelector:
-    matchNames:
-    - logging
   selector:
     matchLabels:
-      name: opensearch-dashboards
-      instance: opensearch-dashboards
+      app.kubernetes.io/name: opensearch-dashboards
+      app.kubernetes.io/instance: opensearch-dashboards
   endpoints:
   - port: metrics
     interval: 10s

--- a/katalog/opensearch-dashboards/kustomization.yaml
+++ b/katalog/opensearch-dashboards/kustomization.yaml
@@ -5,22 +5,17 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 namespace: logging
-
 resources:
   - deploy.yaml
   - index-patterns-cronjob.yml
-
 images:
   - name: registry.sighup.io/fury/opensearchproject/opensearch-dashboards
-    newTag: "2.19.1"
-
+    newTag: "3.2.0"
 secretGenerator:
   - name: opensearch-dashboards
     files:
       - configs/opensearch_dashboards.yml
-
 configMapGenerator:
   - name: opensearch-index-patterns
     files:

--- a/katalog/opensearch-single/MAINTENANCE.md
+++ b/katalog/opensearch-single/MAINTENANCE.md
@@ -9,8 +9,8 @@ To maintain the OpenSearch package, you should follow these steps.
 3. Run the following commands:
 
   ```bash
-  VERSION=2.32.0 # update this to the latest chart version
-  IMAGE_TAG="2.19.1" # update this to the latest fury/opensearchproject/opensearch image tag
+  VERSION=3.2.0 # update this to the latest chart version
+  IMAGE_TAG="3.2.0" # update this to the latest fury/opensearchproject/opensearch image tag
   helm repo add opensearch https://opensearch-project.github.io/helm-charts/
   helm repo update
   helm pull opensearch/opensearch --version $VERSION --untar --untardir /tmp # this command will download the chart in /tmp/opensearch
@@ -19,7 +19,7 @@ To maintain the OpenSearch package, you should follow these steps.
   ```
 
   > [!TIP]
-  > Chart v2.32.0 uses OpenSearch v2.19.1
+  > Chart v3.2.0 uses OpenSearch v3.2.0
 
 The provided values will deploy a custom `fsgroups` initContainer, because the one provided with vanilla values
 does not change the `fs.file-max` value with `sysctl`.

--- a/katalog/opensearch-single/MAINTENANCE.values.yaml
+++ b/katalog/opensearch-single/MAINTENANCE.values.yaml
@@ -27,7 +27,7 @@ extraEnvs:
 image:
   repository: "registry.sighup.io/fury/opensearchproject/opensearch"
   # override image tag, which is .Chart.AppVersion by default
-  tag: ""
+  tag: "3.2.0"
   pullPolicy: "IfNotPresent"
 
 opensearchJavaOpts: "-Xms2G -Xmx2G"
@@ -119,7 +119,6 @@ enableServiceLinks: true
 protocol: http
 httpPort: 9200
 transportPort: 9300
-metricsPort: 9108
 httpHostPort: ""
 transportHostPort: ""
 

--- a/katalog/opensearch-single/README.md
+++ b/katalog/opensearch-single/README.md
@@ -19,7 +19,7 @@ Kubernetes.
 
 ## Image repository and tag
 
-- OpenSearch image: `opensearchproject/opensearch:2.17.1`
+- OpenSearch image: `opensearchproject/opensearch:3.2.0`
 - OpenSearch repo: [OpenSearch on Github][opensearch-gh]
 - OpenSearch documentation: [OpenSearch Homepage][opensearch-doc]
 

--- a/katalog/opensearch-single/deploy.yaml
+++ b/katalog/opensearch-single/deploy.yaml
@@ -40,9 +40,6 @@ spec:
   - name: transport
     protocol: TCP
     port: 9300
-  - name: metrics
-    protocol: TCP
-    port: 9108
 ---
 # Source: opensearch/templates/service.yaml
 kind: Service
@@ -76,7 +73,7 @@ metadata:
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: opensearch
   annotations:
-    majorVersion: "2"
+    majorVersion: "3"
 spec:
   serviceName: opensearch-cluster-master-headless
   selector:
@@ -176,7 +173,7 @@ spec:
           runAsGroup: 1000
           runAsNonRoot: true
           runAsUser: 1000
-        image: "registry.sighup.io/fury/opensearchproject/opensearch:2.19.1"
+        image: "registry.sighup.io/fury/opensearchproject/opensearch:3.2.0"
         imagePullPolicy: "IfNotPresent"
         readinessProbe:
           failureThreshold: 3

--- a/katalog/opensearch-single/kustomization.yaml
+++ b/katalog/opensearch-single/kustomization.yaml
@@ -7,11 +7,13 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: logging
 images:
+  - name: registry.sighup.io/fury/opensearchproject/opensearch
+    newTag: "3.2.0"
   - name: quay.io/prometheuscommunity/elasticsearch-exporter
     newName: registry.sighup.io/fury/prometheuscommunity/elasticsearch-exporter
     newTag: "v1.8.0"
   - name: registry.sighup.io/fury/opensearchproject/opensearch-dashboards
-    newTag: "2.19.1"
+    newTag: "3.2.0"
   - name: alpine
     newName: registry.sighup.io/fury/alpine
     newTag: "3.14"


### PR DESCRIPTION
### Summary 💡

This PR updates opensearch and opensearch-dashboard to 3.2.0. It's a major upgrade but there should be no breaking changes for the user, at least on how we use opensearch in the distro, to store logs.

### Breaking Changes 💔

- None in how we use opensearch

### Tests performed 🧪

- [ ] local e2e tests
- [ ] CI e2e tests

