### PR TITLE
fix(configs): remove json parser from kubernetes flow

### DIFF
--- a/katalog/configs/kubernetes/cluster-flow.yml
+++ b/katalog/configs/kubernetes/cluster-flow.yml
@@ -12,14 +12,6 @@ spec:
     - dedot:
         de_dot_separator: "_"
         de_dot_nested: true
-    # Added parser json on key message to parse containerd json logs
-    - parser:
-        key_name: message
-        parse:
-          type: json
-        remove_key_name_field: true
-        reserve_data: true
-        emit_invalid_record_to_error: false
   match:
     - exclude:
         namespaces:


### PR DESCRIPTION
### Summary 💡

Remove JSON parser from the kubernetes flow.

Fixes #197

### Description 📝

Remove JSON parser from the kubernetes flow.

Being that the kubernetes flow picks up logs from all the applicative workload, that we can't know before hand, it does not make sense to have the JSON parser with a predefined key (`message`) that may or may not exist.

When the key does not exists but logs have JSON format the parser does not detect properly the date falling back to the epoch (1970-01-01).

The parser has been added by [this commit](https://github.com/sighupio/module-logging/commit/fc4608b2b83ea9ff3ac0b7188e55f6cbf9fdf71b) with a comment saying that it was needed to parse containerd logs, but containerd logs are no in the kubernetes flow, they are picked up by the systemd flows.

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] Tested the change with SD version 1.32.0 with OpenSearch. Logs get the current date, both JSON logs and "string" logs.
- [x] Tested the change with SD version 1.32.0 with Loki. Logs get the current date, both JSON logs and "string" logs.
- [x] Tested the change with SD version 1.33.0-rc.0 with OpenSearch. Logs get the current date, both JSON logs and "string" logs.
- [x] Tested the change with SD version 1.33.0-rc.0 with Loki. Logs get the current date, both JSON logs and "string" logs.

### Future work 🔧

None